### PR TITLE
Legger til swagger

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,16 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.springfox</groupId>
+            <artifactId>springfox-swagger2</artifactId>
+            <version>2.9.2</version>
+        </dependency>
+        <dependency>
+            <groupId>io.springfox</groupId>
+            <artifactId>springfox-swagger-ui</artifactId>
+            <version>2.9.2</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/SwaggerConfig.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/SwaggerConfig.java
@@ -1,0 +1,24 @@
+package no.nav.tag.tiltaksgjennomforing;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+@Configuration
+@EnableSwagger2
+public class SwaggerConfig {
+
+    @Bean
+    public Docket api() {
+        return new Docket(DocumentationType.SWAGGER_2)
+          .select()
+          .apis(RequestHandlerSelectors.any())
+          .paths(PathSelectors.any())
+          .build();
+    }
+}

--- a/src/main/java/no/nav/tag/tiltaksgjennomforing/TiltaksgjennomforingApplication.java
+++ b/src/main/java/no/nav/tag/tiltaksgjennomforing/TiltaksgjennomforingApplication.java
@@ -2,7 +2,6 @@ package no.nav.tag.tiltaksgjennomforing;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.web.bind.annotation.RestController;
 
 @SpringBootApplication
 public class TiltaksgjennomforingApplication {


### PR DESCRIPTION
Legger inn støtte for swagger med springfox-swagger2. Rå copy/paste fra 
https://www.baeldung.com/swagger-2-documentation-for-spring-rest-api

Dette funker tilsynelatende bra, og man kan bruke swagger-ui til å teste APIet med.
MEN det er foreløpig ingen sikkerhetsmekanismer her. Før dette går i prod bør vi vurdere hva som skal være eksponert og kanskje flytte ui til en url under internal.